### PR TITLE
French translation: use capital letters for settings values

### DIFF
--- a/locale/fr-FR/options.dtd
+++ b/locale/fr-FR/options.dtd
@@ -9,11 +9,11 @@
 <!ENTITY tab-height.desc "Choisissez &#171;-1&#187; ou &#171;0&#187; pour utiliser la valeur par défaut du thème (&#171;-1&#187; par défaut)">
 <!ENTITY highlight-unloaded-tabs.title "Coloration des onglets non-chargés:">
 <!ENTITY highlight-unloaded-tabs.desc "Si vous utilisez l’option de Firefox &#171;Ne pas charger les onglets tant qu'ils ne sont pas sélectionnés&#187; (&#171;non&#187; par défaut)">
-<!ENTITY highlight-unloaded-tabs.no "aucune">
-<!ENTITY highlight-unloaded-tabs.grayout "grisé">
-<!ENTITY highlight-unloaded-tabs.highlight "surligné">
+<!ENTITY highlight-unloaded-tabs.no "Aucune">
+<!ENTITY highlight-unloaded-tabs.grayout "Grisé">
+<!ENTITY highlight-unloaded-tabs.highlight "Surligné">
 <!ENTITY highlight-unread-tabs.title "Colorer les onglets non-lus:">
-<!ENTITY highlight-unread-tabs.desc "(non-coché par défaut)">
+<!ENTITY highlight-unread-tabs.desc "(Non-coché par défaut)">
 <!ENTITY tab-numbers.title "Afficher les numéros d’onglets dans les titres des onglets:">
 <!ENTITY tab-numbers.desc "Pratique pour les extensions de type Vim (non-coché par défaut)">
 <!ENTITY dblclick.title "Double clic:">
@@ -44,10 +44,10 @@
 <!ENTITY drawInTitlebar.desc "Option &#171;browser.tabs.drawInTitlebar&#187; dans about:config (coché par défaut)">
 <!ENTITY after-close.title "Quand l'onglet courant est fermé, activer:">
 <!ENTITY after-close.desc "Le choix «l’onglet le plus proche» correspond à l’ordre: premier fils → frère du dessous → frère du dessus → parent (&#171;le dernier onglet sélectionné&#187; par défaut)">
-<!ENTITY after-close.0 "l'onglet par défaut (onglet l'ayant ouvert/à droite)">
-<!ENTITY after-close.1 "le dernier onglet sélectionné">
-<!ENTITY after-close.2 "l'onglet le plus proche">
-<!ENTITY after-close.3 "l’onglet juste au dessus">
+<!ENTITY after-close.0 "L'onglet par défaut (onglet l'ayant ouvert/à droite)">
+<!ENTITY after-close.1 "Le dernier onglet sélectionné">
+<!ENTITY after-close.2 "L'onglet le plus proche">
+<!ENTITY after-close.3 "L’onglet juste au dessus">
 <!ENTITY new-tab-button.title "Montrer le bouton &#171;Ouvrir un nouvel onglet (Ctrl+T)&#187;:">
 <!ENTITY new-tab-button.desc "Vous pouvez aussi double-cliquer dans une zone vide en dessous des onglets pour ouvrir un nouvel onglet (coché par défaut)">
 <!ENTITY close-tab-buttons.title "Montrer le bouton &#171;Fermer l'onglet&#187;:">
@@ -55,13 +55,13 @@
 <!ENTITY max-indent.title "Niveau max d’indentation des onglets:">
 <!ENTITY max-indent.desc "Lors de l’ouverture d’un onglet. &#171;-1&#187; signifie qu’il n’y a pas de niveau max (&#171;-1&#187; par défaut)">
 <!ENTITY wheel.title "Défilement sur l’arbre des onglets:">
-<!ENTITY wheel.desc "(premier choix par défaut)">
+<!ENTITY wheel.desc "(Premier choix par défaut)">
 <!ENTITY wheel.0 "Sans Maj - défiler normalement, avec Maj - changer l’onglet actif">
 <!ENTITY wheel.1 "Sans Maj - changer l’onglet actif, avec Maj- défiler normalement">
-<!ENTITY wheel.2 "toujours défiler normalement">
-<!ENTITY wheel.3 "toujours changer l’onglet actif">
+<!ENTITY wheel.2 "Toujours défiler normalement">
+<!ENTITY wheel.3 "Toujours changer l’onglet actif">
 <!ENTITY search-jump.title "La recherche d'onglet saute au premier onglet correspondant:">
-<!ENTITY search-jump.desc "(décoché par défaut)">
+<!ENTITY search-jump.desc "(Décoché par défaut)">
 <!ENTITY search-jump-min-chars.title "Nombre min. de caractères pour sauter:">
 <!ENTITY search-jump-min-chars.desc "(4 par défaut)">
 <!ENTITY auto-hide-key.title "Touche pour basculer le masquage automatique">
@@ -75,9 +75,9 @@
 <!ENTITY auto-hide-when-only-one-tab.title "Cacher automatiquement l'arbre d'onglets quand il y a un seul onglet">
 <!ENTITY auto-hide-when-only-one-tab.desc "La touche définie au dessus bascule cette option si une fenêtre active n'a qu'un seul onglet (utilisez Ctrl+T pour ouvrir un nouvel onglet, coché par défaut)">
 <!ENTITY insertRelatedAfterCurrent.title "Insérer un nouvel onglet fils:">
-<!ENTITY insertRelatedAfterCurrent.desc "(«en bas» par défaut)">
-<!ENTITY insertRelatedAfterCurrent.top "en haut">
-<!ENTITY insertRelatedAfterCurrent.bottom "en bas">
+<!ENTITY insertRelatedAfterCurrent.desc "(«En bas» par défaut)">
+<!ENTITY insertRelatedAfterCurrent.top "En haut">
+<!ENTITY insertRelatedAfterCurrent.bottom "En bas">
 <!ENTITY prefix-context-menu-items.title "Préfixe des éléments du menu contextuel avec &#171;Tab Tree:&#187;:">
 <!ENTITY prefix-context-menu-items.desc "Si vous voulez &#171;Tab Tree: Fermer les fils&#187; au lieu de seulement &#171;Fermer les fil&#187; (décoché par défaut)">
 <!ENTITY tab-flip.title "Basculement d'onglet:">


### PR DESCRIPTION
I think that the labels for values should always use capitals or never. In this patch, I made sure that all values labels start with an uppercase letter.
If you agree with that, you could use it as a part of your pull request "fix and improve the French translation".